### PR TITLE
Avoid double output when luv/h8 and ++/-- are combined

### DIFF
--- a/rep.py
+++ b/rep.py
@@ -36,7 +36,10 @@ def luv_h8_cmd(bot, trigger):
         bot.reply("No user specified.")
         return
     target = Identifier(trigger.group(3))
-    if target != verified_nick(bot, target, trigger.sender):  # guard against double-processing karma_cmd() matches
+    v_nick = verified_nick(bot, target, trigger.sender)
+    if not v_nick:
+        return
+    if target != v_nick:  # guard against double-processing karma_cmd() matches
         return
     luv_h8(bot, trigger, target, trigger.group(1))
 
@@ -133,6 +136,8 @@ def is_self(bot, nick, target):
 
 def verified_nick(bot, nick, channel):
     nick = re.search('([a-zA-Z0-9\[\]\\`_\^\{\|\}-]{1,32})', nick).group(1)
+    if not nick:
+        return None
     nick = Identifier(nick)
     if nick.lower() not in bot.privileges[channel.lower()]:
         if nick.endswith('--'):

--- a/rep.py
+++ b/rep.py
@@ -33,6 +33,8 @@ def luv_h8_cmd(bot, trigger):
         bot.reply("No user specified.")
         return
     target = Identifier(trigger.group(3))
+    if target != verified_nick(bot, target, trigger.sender):  # guard against double-processing karma_cmd() matches
+        return
     luv_h8(bot, trigger, target, trigger.group(1))
 
 

--- a/rep.py
+++ b/rep.py
@@ -36,11 +36,6 @@ def luv_h8_cmd(bot, trigger):
         bot.reply("No user specified.")
         return
     target = Identifier(trigger.group(3))
-    v_nick = verified_nick(bot, target, trigger.sender)
-    if not v_nick:
-        return
-    if target != v_nick:  # guard against double-processing karma_cmd() matches
-        return
     luv_h8(bot, trigger, target, trigger.group(1))
 
 

--- a/rep.py
+++ b/rep.py
@@ -21,6 +21,9 @@ def heart_cmd(bot, trigger):
 @module.rule('.*?(?:([a-zA-Z0-9\[\]\\`_\^\{\|\}-]{1,32})(\+{2}|-{2})).*?')
 @module.require_chanmsg("You may only modify someone's rep in a channel.")
 def karma_cmd(bot, trigger):
+    if re.match('^({prefix})({cmds})'.format(prefix=bot.config.core.prefix, cmds='|'.join(luv_h8_cmd.commands)),
+                trigger.group(0)):
+        return  # avoid processing commands if people try to be tricky
     luv_h8(bot, trigger, trigger.group(1), 'luv' if trigger.group(2) == '++' else 'h8', warn_nonexistent=False)
 
 


### PR DESCRIPTION
As a side benefit, this better cleans the given nickname in case it has leading/trailing characters that aren't valid in IRC nicks.

Has not been exhaustively tested yet.