### PR TITLE
Fix regex to pick up \ correctly as part of nicks

### DIFF
--- a/rep.py
+++ b/rep.py
@@ -11,20 +11,20 @@ import re
 TIMEOUT = 3600
 
 
-@module.rule('^(</?3)\s+([a-zA-Z0-9\[\]\\`_\^\{\|\}-]{1,32})\s*$')
+@module.rule('^(?P<command></?3)\s+([a-zA-Z0-9\[\]\\\\`_\^\{\|\}-]{1,32})\s*$')
 @module.intent('ACTION')
 @module.require_chanmsg("You may only modify someone's rep in a channel.")
 def heart_cmd(bot, trigger):
     luv_h8(bot, trigger, trigger.group(2), 'h8' if '/' in trigger.group(1) else 'luv')
 
 
-@module.rule('.*?(?:([a-zA-Z0-9\[\]\\`_\^\{\|\}-]{1,32})(\+{2}|-{2})).*?')
+@module.rule('.*?(?:([a-zA-Z0-9\[\]\\\\`_\^\{\|\}-]{1,32})(\+{2}|-{2})).*?')
 @module.require_chanmsg("You may only modify someone's rep in a channel.")
 def karma_cmd(bot, trigger):
     if re.match('^({prefix})({cmds})'.format(prefix=bot.config.core.prefix, cmds='|'.join(luv_h8_cmd.commands)),
                 trigger.group(0)):
         return  # avoid processing commands if people try to be tricky
-    for (nick, act) in re.findall('(?:([a-zA-Z0-9\[\]\\`_\^\{\|\}-]{1,32})(\+{2}|-{2}))', trigger.raw):
+    for (nick, act) in re.findall('(?:([a-zA-Z0-9\[\]\\\\`_\^\{\|\}-]{1,32})(\+{2}|-{2}))', trigger.raw):
         if luv_h8(bot, trigger, nick, 'luv' if act == '++' else 'h8', warn_nonexistent=False):
             break
 
@@ -47,7 +47,12 @@ def luv_h8(bot, trigger, target, which, warn_nonexistent=True):
     pfx = change = selfreply = None  # keep PyCharm & other linters happy
     if not target:
         if warn_nonexistent:
-            bot.reply("You can only %s someone who is here." % which)
+            command = which
+            try:  # because a simple "trigger.group('command') or which" doesn't work
+                command = trigger.group('command')
+            except IndexError:  # why can't you just return None, re.group()?
+                pass
+            bot.reply("You can only %s someone who is here." % command)
         return False
     if rep_too_soon(bot, trigger.nick):
         return False
@@ -133,7 +138,7 @@ def is_self(bot, nick, target):
 
 
 def verified_nick(bot, nick, channel):
-    nick = re.search('([a-zA-Z0-9\[\]\\`_\^\{\|\}-]{1,32})', nick).group(1)
+    nick = re.search('([a-zA-Z0-9\[\]\\\\`_\^\{\|\}-]{1,32})', nick).group(1)
     if not nick:
         return ''  # returning None would mean the returned value can't be compared with ==
     nick = Identifier(nick)


### PR DESCRIPTION
Python escaping is so confusing sometimes.

Fixes #31.