### PR TITLE
Make cooldown configurable without editing the plugin source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Releases are hosted on PyPI, so after installing Sopel, all you need is `pip`:
 $ pip install sopel-rep
 ```
 
+## Configuring
+
+The easiest way to configure `sopel-rep` is via Sopel's configuration
+wizard—simply run `sopel-plugins configure rep` and enter the values for which
+it prompts you. Settings are described below:
+
+* `cooldown`: How long in seconds each user must wait after changing anyone's
+  rep before they are permitted to do so again.\
+  _Default: 3600_
+* `admin_cooldown`: Whether the bot's owner & admins must obey the cooldown.\
+  _Default: true_
+
 ## Usage
 ### Commands
 * `.luv nick`: Adds +1 to the user's reputation score

--- a/sopel_rep/plugin.py
+++ b/sopel_rep/plugin.py
@@ -10,7 +10,7 @@ import re
 import time
 
 from sopel import plugin
-from sopel.config.types import StaticSection, ValidatedAttribute
+from sopel.config.types import BooleanAttribute, StaticSection, ValidatedAttribute
 from sopel.tools import Identifier, time as time_tools
 
 
@@ -19,6 +19,7 @@ r_nick = r'[a-zA-Z0-9\[\]\\`_\^\{\|\}-]{1,32}'
 
 class RepSection(StaticSection):
     cooldown = ValidatedAttribute('cooldown', int, default=3600)
+    admin_cooldown = BooleanAttribute('admin_cooldown', default=True)
 
 
 def setup(bot):
@@ -30,6 +31,10 @@ def configure(config):
     config.rep.configure_setting(
         'cooldown',
         "How often should users be allowed to change someone's rep, in seconds?",
+    )
+    config.rep.configure_setting(
+        'admin_cooldown',
+        "Should bot admins also have to obey that cooldown?",
     )
 
 
@@ -76,7 +81,10 @@ def luv_h8(bot, trigger, target, which, warn_nonexistent=True):
                 pass
             bot.reply("You can only %s someone who is here." % command)
         return False
-    if rep_too_soon(bot, trigger.nick):
+    if (
+        not (trigger.admin and not bot.settings.rep.admin_cooldown)
+        and rep_too_soon(bot, trigger.nick)
+    ):
         return False
     if which == 'luv':
         selfreply = "No narcissism allowed!"


### PR DESCRIPTION
Replaced the TIMEOUT value defined in the code with a config section containing a `cooldown` value, keeping the same default of 3600 seconds. Closes #27.

Also optionally allows admins to bypass the cooldown period, again keeping the old behavior (everyone must obey) as the default.