### PR TITLE
Refactor a bunch of helpers into a manager class + Sopel 8 only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
 
 requires-python = ">=3.8, <4"
 dependencies = [
-  "sopel>=7.1",
+  "sopel>=8.0",
 ]
 
 [project.urls]

--- a/sopel_rep/errors.py
+++ b/sopel_rep/errors.py
@@ -1,0 +1,23 @@
+"""
+Part of sopel-rep
+
+Copyright 2024 dgw, technobabbl.es
+"""
+from __future__ import annotations
+
+
+class ArgumentError(Exception):
+    """Exception to raise if the caller passes invalid arguments."""
+    ...
+
+
+class CooldownError(Exception):
+    """Exception to raise if the caller is in cooldown."""
+    def __init__(self, remaining_time: float):
+        super().__init__()
+        self.remaining_time = remaining_time
+
+
+class NonexistentNickError(Exception):
+    """Exception to raise if someone tries to luv/h8 a nonexistent nick."""
+    ...

--- a/sopel_rep/manager.py
+++ b/sopel_rep/manager.py
@@ -1,0 +1,174 @@
+"""
+Part of sopel-rep
+
+Copyright 2024 dgw, technobabbl.es
+"""
+from __future__ import annotations
+
+import re
+import time
+from typing import TYPE_CHECKING
+
+from .errors import ArgumentError, CooldownError, NonexistentNickError
+
+if TYPE_CHECKING:
+    from sopel.bot import Sopel
+    from sopel.config.types import StaticSection
+    from sopel.tools.identifiers import Identifier
+    from sopel.trigger import Trigger
+
+
+r_nick = r'[a-zA-Z0-9\[\]\\`_\^\{\|\}-]{1,32}'
+
+
+class RepManager:
+    """Manager of reputation actions."""
+
+    SCORE_KEY = 'rep_score'
+    USED_KEY = 'rep_used'
+    LOCKED_KEY = 'rep_locked'
+
+    def __init__(self, bot: Sopel):
+        """Construct a new RepManager.
+
+        :param bot: The Sopel instance under which this plugin is running
+        """
+        self.sopel = bot
+
+    @property
+    def settings(self) -> StaticSection:
+        return self.sopel.settings.rep
+
+    def get_rep(self, nick: str) -> int:
+        return self.sopel.db.get_nick_value(nick, self.SCORE_KEY)
+
+    def set_rep(self, nick: str, value: int):
+        self.sopel.db.set_nick_value(nick, self.SCORE_KEY, value)
+
+    def change_rep(self, nick: str, delta: int) -> int:
+        rep = self.get_rep(nick)
+        rep += delta
+        self.set_rep(nick, rep)
+        return rep
+
+    def lock_rep(self, nick: str):
+        self.sopel.db.set_nick_value(nick, self.LOCKED_KEY, True)
+
+    def unlock_rep(self, nick: str):
+        self.sopel.db.set_nick_value(nick, self.LOCKED_KEY, False)
+
+    def is_rep_locked(self, nick: str) -> bool:
+        return self.sopel.db.get_nick_value(nick, self.LOCKED_KEY) or False
+
+    def get_rep_used(self, nick: str) -> float:
+        return self.sopel.db.get_nick_value(nick, self.USED_KEY) or 0
+
+    def set_rep_used(self, nick: str):
+        self.sopel.db.set_nick_value(nick, self.USED_KEY, time.time())
+
+    def remaining_cooldown(self, nick: str) -> float | None:
+        now = time.time()
+        then = self.get_rep_used(nick)
+        elapsed = now - then
+        cooldown = self.settings.cooldown
+
+        if cooldown > elapsed:
+            return cooldown - elapsed
+        return None
+
+    def nick_is_alias(self, nick1: str, nick2: str) -> bool:
+        nick1 = self.sopel.make_identifier(nick1)
+        nick2 = self.sopel.make_identifier(nick2)
+
+        if nick1 == nick2:
+            # Shortcut to catch common goofballs without hitting the DB
+            return True
+
+        try:
+            id1 = self.sopel.db.get_nick_id(nick1, False)
+            id2 = self.sopel.db.get_nick_id(nick2, False)
+        except ValueError:
+            # If either nick doesn't have an ID, it can't be in a group
+            return False
+
+        return id1 == id2
+
+    def verified_nick(self, nick: str, channel: str) -> Identifier:
+        """Make sure the given `nick` is present in the given `channel`.
+
+        Also performs normalization, casting plain `str` to `Identifier`.
+        """
+        if not all((nick, channel)):
+            # verification should immediately fail if either the `nick` or the
+            # `channel` is falsy. This function always returns '' instead of
+            # None if verification fails, to avoid breaking `==` comparisons
+            return ''
+
+        nick = re.search(r_nick, nick).group(0)
+        if not nick:
+            return ''
+
+        if nick not in self.sopel.channels[channel].users:
+            if nick.endswith('--'):
+                if nick[:-2] in self.sopel.channels[channel].users:
+                    return self.sopel.make_identifier(nick[:-2])
+            return ''
+
+        return self.sopel.make_identifier(nick)
+
+    def luv_or_h8(
+        self,
+        trigger: Trigger,
+        target: str,
+        which: str,  # nominally, either 'luv' or 'h8'
+    ) -> str:
+        """Do the stuff and return what the bot should say.
+
+        `ArgumentError` value is meant to be sent as a bot reply.
+
+        `CooldownError.remaining_time` is meant to be used in a bot notice.
+        """
+        caller = trigger.nick
+        channel = trigger.sender
+        target = self.verified_nick(target, channel)
+        which = which.lower()  # issue #18
+
+        if not target:
+            raise NonexistentNickError(
+                "You can only {} someone who is here.".format(which))
+
+        remains = self.remaining_cooldown(caller)
+        if (
+            remains and not (
+                trigger.admin and not self.settings.admin_cooldown)
+        ):
+            raise CooldownError(remains)
+
+        selfreply = verb = delta = None
+        if which == 'luv':
+            selfreply = "No narcissism allowed!"
+            verb, delta = 'increased', 1
+        elif which == 'h8':
+            selfreply = "Go to 4chan if you really hate yourself!"
+            verb, delta = 'decreased', -1
+        else:
+            raise RuntimeError("Invalid `which`: {!r}.".format(which))
+
+        if self.nick_is_alias(caller, target):
+            raise ArgumentError(selfreply)
+
+        possessive = 'my' if target == self.sopel.nick else target + "'s"
+        if self.is_rep_locked(target):
+            raise ArgumentError(
+                "Sorry, {} reputation has been locked by an admin."
+                .format(possessive)
+            )
+
+        new_rep = self.change_rep(target, delta)
+        self.set_rep_used(caller)
+        return "{who} has {change} {whose} reputation score to {what}.".format(
+            who=caller,
+            change=verb,
+            whose=possessive,
+            what=new_rep,
+        )

--- a/sopel_rep/plugin.py
+++ b/sopel_rep/plugin.py
@@ -7,14 +7,13 @@ Copyright 2015-2024 dgw
 from __future__ import annotations
 
 import re
-import time
 
 from sopel import plugin
 from sopel.config.types import BooleanAttribute, StaticSection, ValidatedAttribute
-from sopel.tools import Identifier, time as time_tools
+from sopel.tools import time as time_tools
 
-
-r_nick = r'[a-zA-Z0-9\[\]\\`_\^\{\|\}-]{1,32}'
+from .errors import ArgumentError, CooldownError, NonexistentNickError
+from .manager import RepManager, r_nick
 
 
 class RepSection(StaticSection):
@@ -23,7 +22,10 @@ class RepSection(StaticSection):
 
 
 def setup(bot):
+    global MANAGER
+
     bot.config.define_section('rep', RepSection)
+    MANAGER = RepManager(bot)
 
 
 def configure(config):
@@ -64,47 +66,29 @@ def luv_h8_cmd(bot, trigger):
     if not trigger.group(3):
         bot.reply("No user specified.")
         return
-    target = Identifier(trigger.group(3))
-    luv_h8(bot, trigger, target, trigger.group(1))
+
+    luv_h8(bot, trigger, trigger.group(3), trigger.group(1))
 
 
 def luv_h8(bot, trigger, target, which, warn_nonexistent=True):
-    target = verified_nick(bot, target, trigger.sender)
-    which = which.lower()  # issue #18
-    pfx = change = selfreply = None  # keep PyCharm & other linters happy
-    if not target:
+    try:
+        message = MANAGER.luv_or_h8(trigger, target, which)
+    except NonexistentNickError as err:
         if warn_nonexistent:
-            command = which
-            try:  # because a simple "trigger.group('command') or which" doesn't work
-                command = trigger.group('command')
-            except IndexError:  # why can't you just return None, re.group()?
-                pass
-            bot.reply("You can only %s someone who is here." % command)
+            bot.reply(str(err))
         return False
-    if (
-        not (trigger.admin and not bot.settings.rep.admin_cooldown)
-        and rep_too_soon(bot, trigger.nick)
-    ):
+    except ArgumentError as err:
+        bot.reply(str(err))
         return False
-    if which == 'luv':
-        selfreply = "No narcissism allowed!"
-        pfx, change = 'in', 1
-    if which == 'h8':
-        selfreply = "Go to 4chan if you really hate yourself!"
-        pfx, change = 'de', -1
-    if not (pfx and change and selfreply):  # safeguard against leaving something in the above mass-None assignment
-        bot.say("Logic error! Please report this to %s." % bot.config.core.owner)
-        return
-    if is_self(bot, trigger.nick, target):
-        bot.reply(selfreply)
+    except CooldownError as err:
+        bot.notice(
+            "You can change someone's rep again {}."
+            .format(time_tools.seconds_to_human(-err.remaining_time)),
+            trigger.nick,
+        )
         return False
 
-    possessive = 'my' if target == bot.nick else target + "'s"
-    if bot.db.get_nick_value(target, 'rep_locked'):
-        bot.reply("Sorry, %s reputation has been locked by an admin." % possessive)
-        return False
-    rep = mod_rep(bot, trigger.nick, target, change)
-    bot.say("%s has %screased %s reputation score to %d" % (trigger.nick, pfx, possessive, rep))
+    bot.say(message)
     return True
 
 
@@ -112,7 +96,7 @@ def luv_h8(bot, trigger, target, which, warn_nonexistent=True):
 @plugin.example(".rep johnnytwothumbs")
 def show_rep(bot, trigger):
     target = trigger.group(3) or trigger.nick
-    rep = get_rep(bot, target)
+    rep = MANAGER.get_rep(target)
     if rep is None:
         bot.say("%s has no reputation score yet." % target)
         return
@@ -127,80 +111,9 @@ def manage_locks(bot, trigger):
     if not target:
         bot.reply("I need a nickname!")
         return
-    if 'un' in trigger.group(1):  # .repunlock command used
-        bot.db.set_nick_value(Identifier(target), 'rep_locked', False)
+    if 'unlock' in trigger.group(1):  # .repunlock command used
+        MANAGER.unlock_rep(target)
         bot.say("Unlocked rep for %s." % target)
     else:  # .replock command used
-        bot.db.set_nick_value(Identifier(target), 'rep_locked', True)
+        MANAGER.lock_rep(target)
         bot.say("Locked rep for %s." % target)
-
-
-# helpers
-def get_rep(bot, target):
-    return bot.db.get_nick_value(Identifier(target), 'rep_score')
-
-
-def set_rep(bot, caller, target, newrep):
-    bot.db.set_nick_value(Identifier(target), 'rep_score', newrep)
-    bot.db.set_nick_value(Identifier(caller), 'rep_used', time.time())
-
-
-def mod_rep(bot, caller, target, change):
-    rep = get_rep(bot, target) or 0
-    rep += change
-    set_rep(bot, caller, target, rep)
-    return rep
-
-
-def get_rep_used(bot, nick):
-    return bot.db.get_nick_value(Identifier(nick), 'rep_used') or 0
-
-
-def set_rep_used(bot, nick):
-    bot.db.set_nick_value(Identifier(nick), 'rep_used', time.time())
-
-
-def rep_used_since(bot, nick):
-    now = time.time()
-    last = get_rep_used(bot, nick)
-    return abs(last - now)
-
-
-def rep_too_soon(bot, nick):
-    since = rep_used_since(bot, nick)
-    cooldown = bot.settings.rep.cooldown
-    if since < cooldown:
-        bot.notice("You can change someone's rep again %s." % time_tools.seconds_to_human(-(cooldown - since)), nick)
-        return True
-    else:
-        return False
-
-
-def is_self(bot, nick, target):
-    nick = Identifier(nick)
-    target = Identifier(target)
-    if nick == target:
-        return True  # shortcut to catch common goofballs
-    try:
-        nick_id = bot.db.get_nick_id(nick, False)
-        target_id = bot.db.get_nick_id(target, False)
-    except ValueError:
-        return False  # if either nick doesn't have an ID, they can't be in a group
-    return nick_id == target_id
-
-
-def verified_nick(bot, nick, channel):
-    if not all([nick, channel]):
-        # `bot` is always going to be a thing, but `nick` or `channel` could be empty
-        # and that means verification should immediately fail
-        return ''  # not None; see below
-
-    nick = re.search(r_nick, nick).group(0)
-    if not nick:
-        return ''  # returning None would mean the returned value can't be compared with ==
-    if nick not in bot.channels[channel].users:
-        if nick.endswith('--'):
-            if nick[:-2] in bot.channels[channel].users:
-                return Identifier(nick[:-2])
-        return ''  # see above
-    return Identifier(nick)

--- a/sopel_rep/plugin.py
+++ b/sopel_rep/plugin.py
@@ -22,10 +22,12 @@ class RepSection(StaticSection):
 
 
 def setup(bot):
-    global MANAGER
-
     bot.config.define_section('rep', RepSection)
-    MANAGER = RepManager(bot)
+    bot.memory['rep_manager'] = RepManager(bot)
+
+
+def shutdown(bot):
+    del bot.memory['rep_manager']
 
 
 def configure(config):
@@ -72,7 +74,7 @@ def luv_h8_cmd(bot, trigger):
 
 def luv_h8(bot, trigger, target, which, warn_nonexistent=True):
     try:
-        message = MANAGER.luv_or_h8(trigger, target, which)
+        message = bot.memory['rep_manager'].luv_or_h8(trigger, target, which)
     except NonexistentNickError as err:
         if warn_nonexistent:
             bot.reply(str(err))
@@ -96,7 +98,7 @@ def luv_h8(bot, trigger, target, which, warn_nonexistent=True):
 @plugin.example(".rep johnnytwothumbs")
 def show_rep(bot, trigger):
     target = trigger.group(3) or trigger.nick
-    rep = MANAGER.get_rep(target)
+    rep = bot.memory['rep_manager'].get_rep(target)
     if rep is None:
         bot.say("%s has no reputation score yet." % target)
         return
@@ -112,8 +114,8 @@ def manage_locks(bot, trigger):
         bot.reply("I need a nickname!")
         return
     if 'unlock' in trigger.group(1):  # .repunlock command used
-        MANAGER.unlock_rep(target)
+        bot.memory['rep_manager'].unlock_rep(target)
         bot.say("Unlocked rep for %s." % target)
     else:  # .replock command used
-        MANAGER.lock_rep(target)
+        bot.memory['rep_manager'].lock_rep(target)
         bot.say("Locked rep for %s." % target)


### PR DESCRIPTION
Went Sopel 8+ only because of the new `bot.make_identifier()` helper method, and the stronger checks around `SopelIdentifierMemory` keys (used for things like channels/users), and the better enforcement in `bot.db` of making sure the nick passed to `*_nick_value` methods is correctly treated as an `Identifier`.

Basically, Sopel 7 is still a bit of a slopfest when it comes to dealing with `Identifier` values correctly when compared to 8. I wanted to get rid of as many typecasts in the plugin code as possible.

This PR is a draft because I haven't tested it _that_ thoroughly yet. It was already late when I started, and now it's even later, so I'm calling it quits for the night after reaching the point of "well, it _seems_ to work" when I toss the easy cases at it.