### PR TITLE
Use `search` decorator to look for inline karma commands

### DIFF
--- a/sopel_rep/plugin.py
+++ b/sopel_rep/plugin.py
@@ -16,6 +16,9 @@ from .errors import ArgumentError, CooldownError, NonexistentNickError
 from .manager import RepManager, r_nick
 
 
+KARMA_INLINE = r'(%s)(\+{2}|-{2})' % r_nick
+
+
 class RepSection(StaticSection):
     cooldown = ValidatedAttribute('cooldown', int, default=3600)
     admin_cooldown = BooleanAttribute('admin_cooldown', default=True)
@@ -49,13 +52,13 @@ def heart_cmd(bot, trigger):
     luv_h8(bot, trigger, trigger.group(2), 'h8' if '/' in trigger.group(1) else 'luv')
 
 
-@plugin.rule(r'.*?(?:(%s)(\+{2}|-{2})).*?' % r_nick)
+@plugin.search(KARMA_INLINE)
 @plugin.require_chanmsg("You may only modify someone's rep in a channel.")
 def karma_cmd(bot, trigger):
     if re.match('^({prefix})({cmds})'.format(prefix=bot.config.core.prefix, cmds='|'.join(luv_h8_cmd.commands)),
                 trigger.group(0)):
         return  # avoid processing commands if people try to be tricky
-    for (nick, act) in re.findall(r'(?:(%s)(\+{2}|-{2}))' % r_nick, trigger.raw):
+    for (nick, act) in re.findall(KARMA_INLINE, trigger.raw):
         if luv_h8(bot, trigger, nick, 'luv' if act == '++' else 'h8', warn_nonexistent=False):
             break
 


### PR DESCRIPTION
This allows reusing the same pattern defined as a module-level constant in `sopel_rep.plugin` instead of building it multiple times to suit different contexts.

Note: Cannot switch to the `find` decorator because each match triggers a separate instance of the decorated callable; the "first valid action" logic in `karma_cmd()` wouldn't work with that.

I think this resolves #36; can't see anything else obvious in the plugin that could use updating as far as decorators/matching.