### PR TITLE
manager: have `get_rep()` return 0 if the DB contains no rep value

### DIFF
--- a/sopel_rep/manager.py
+++ b/sopel_rep/manager.py
@@ -40,7 +40,7 @@ class RepManager:
         return self.sopel.settings.rep
 
     def get_rep(self, nick: str) -> int:
-        return self.sopel.db.get_nick_value(nick, self.SCORE_KEY)
+        return self.sopel.db.get_nick_value(nick, self.SCORE_KEY) or 0
 
     def set_rep(self, nick: str, value: int):
         self.sopel.db.set_nick_value(nick, self.SCORE_KEY, value)


### PR DESCRIPTION
Type-checking probably would have caught this, though not with a default clone of Sopel's repo (it doesn't have the `py.typed` marker yet).

Alas, I'm not disciplined enough to have set up mypy on this old repo.

But this is why I load up a test bot before cutting a new release. Usually. (Again, what is discipline?)
